### PR TITLE
Use prerelease field from main repo release.

### DIFF
--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -10,13 +10,16 @@ on:
 jobs:
   import:
     runs-on: macos-latest
+    env:
+      MAIN_REPO_OWNER: BranchMetrics
+      MAIN_REPO_REPO: ios-branch-deep-linking-attribution
     steps:
       - name: Check out SPM repo
         uses: actions/checkout@v2
       - name: Check out main iOS repo
         uses: actions/checkout@v2
         with:
-          repository: BranchMetrics/ios-branch-deep-linking-attribution
+          repository: ${{ env.MAIN_REPO_OWNER }}/${{ env.MAIN_REPO_REPO }}
           ref: ${{ github.event.inputs.tag }}
           path: .ios-repo
       - name: Import release ${{ github.event.inputs.tag }}
@@ -31,10 +34,12 @@ jobs:
           script: |
             const tag = '${{ github.event.inputs.tag }}';
             const sha = '${{ steps.import-release.outputs.sha }}';
+            const mainRepoOwner = '${{ env.MAIN_REPO_OWNER }}';
+            const mainRepoRepo = '${{ env.MAIN_REPO_REPO }}';
 
             const { data } = await github.repos.getReleaseByTag({
-              owner: 'BranchMetrics',
-              repo: 'ios-branch-deep-lining-attribution',
+              owner: mainRepoOwner,
+              repo: mainRepoRepo,
               tag,
             });
 

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -49,6 +49,6 @@ jobs:
               target_commitish: sha,
               tag_name: tag,
               name: tag,
-              body: `Mirror of https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/releases/${tag}`,
+              body: `Mirror of https://github.com/${mainRepoOwner}/${mainRepoRepo}/releases/${tag}`,
               prerelease: data.prelease,
             });

--- a/.github/workflows/import.yml
+++ b/.github/workflows/import.yml
@@ -31,6 +31,13 @@ jobs:
           script: |
             const tag = '${{ github.event.inputs.tag }}';
             const sha = '${{ steps.import-release.outputs.sha }}';
+
+            const { data } = await github.repos.getReleaseByTag({
+              owner: 'BranchMetrics',
+              repo: 'ios-branch-deep-lining-attribution',
+              tag,
+            });
+
             await github.repos.createRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -38,4 +45,5 @@ jobs:
               tag_name: tag,
               name: tag,
               body: `Mirror of https://github.com/BranchMetrics/ios-branch-deep-linking-attribution/releases/${tag}`,
+              prerelease: data.prelease,
             });


### PR DESCRIPTION
This allows prerelease tags in the main repo for testing. In particular it allows this import workflow to be tested without generating full releases, preventing SPM users from accidentally using a test tag.

@BranchMetrics/core-team 